### PR TITLE
[auto-editor] Use python-installer instead of python-pip to create package

### DIFF
--- a/pkgs/auto-editor/PKGBUILD
+++ b/pkgs/auto-editor/PKGBUILD
@@ -3,24 +3,26 @@
 
 pkgname=auto-editor
 pkgver=25.0.1
-pkgrel=1
+pkgrel=2
 pkgdesc="A command line application for automatically editing video and audio."
 url="https://auto-editor.com/"
 arch=('any')
 license=("Unlicense")
 depends=('python' 'python-numpy' 'python-av')
 optdepends=('yt-dlp: download and use URLs as inputs')
-makedepends=('python-setuptools' 'python-build' 'python-pip')
+makedepends=('python-build' 'python-installer' 'python-wheel')
 source=("$pkgname-$pkgver.tar.gz::https://github.com/WyattBlue/auto-editor/archive/refs/tags/${pkgver}.tar.gz")
 sha256sums=('6cd5e08223fa8d36727fc31422f8a7d30a87ff877ced5732a64543be1b20542c')
 
 build() {
 	cd auto-editor-$pkgver
-	python -m build
+	python -m build --wheel --no-isolation
 }
 
 package() {
 	cd auto-editor-$pkgver
-	python -m pip install --no-dependencies --root="$pkgdir" dist/*.whl
+
+	python -m installer --destdir="$pkgdir" dist/*.whl
+
 	install -Dm644 LICENSE "$pkgdir/usr/share/licenses/$pkgname/LICENSE"
 }


### PR DESCRIPTION
[Reported by escape0707 in the AUR comments](https://aur.archlinux.org/packages/auto-editor#comment-987417)

Relevant Wiki Page: [https://wiki.archlinux.org/title/Python_package_guidelines#Standards_based_(PEP_517)](https://wiki.archlinux.org/title/Python_package_guidelines#Standards_based_(PEP_517))
