### PR TITLE
[friends] Remove automaticUpdates

### DIFF
--- a/pkgs/friends/.aurmanifest.json
+++ b/pkgs/friends/.aurmanifest.json
@@ -3,9 +3,5 @@
 	"testCmd": "friends --version",
 	"include": [
 		"friends"
-	],
-	"automaticUpdates": {
-		"type": "github-tags",
-		"repo": "JacobEvelyn/friends"
-	}
+	]
 }


### PR DESCRIPTION
The github-tag provider is kinda broken right now and doesn't reliably surface the latest tag, so we'll just ignore the problem for now.
